### PR TITLE
Print `total_cycles` in PR description

### DIFF
--- a/.github/workflows/build-guest.yml
+++ b/.github/workflows/build-guest.yml
@@ -28,7 +28,8 @@ jobs:
     name: Docker containerized build of guest programs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: chunk commitments (prover)
         id: commitments-chunk-prover
@@ -137,3 +138,9 @@ jobs:
           make build-guest
           git diff
           git diff --quiet && echo "no diff" || (echo "diff"; exit 1)
+
+      - name: Upload artifact (chunk app.vmexe)
+        uses: actions/upload-artifact@v2
+        with:
+          name: chunk-app-vmexe
+          path: ./crates/circuits/chunk-circuit/openvm/app.vmexe

--- a/.github/workflows/build-guest.yml
+++ b/.github/workflows/build-guest.yml
@@ -22,6 +22,7 @@ on:
       - crates/circuits/batch-circuit/**/*
       - crates/circuits/bundle-circuit/**/*
       - crates/build-guest/**/*
+  workflow_dispatch:
 
 jobs:
   docker-build-guest:

--- a/.github/workflows/profile-guest.yml
+++ b/.github/workflows/profile-guest.yml
@@ -1,0 +1,50 @@
+name: Profile Guest
+
+on:
+  workflow_run:
+    workflows: ["Build Guest"]
+    types:
+      - completed
+
+jobs:
+  profile-guest:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download artifact (chunk app.vmexe)
+        uses: actions/download-artifact@v2
+        with:
+          name: chunk-app-vmexe
+          path: ./crates/circuits/chunk-circuit/openvm/
+
+      - name: Setup rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-12-06
+
+      - name: Guest profiling to capture total_cycles
+        id: guest-profiling
+        run: |
+          # Run the tests and capture the output
+          output=$(make profile-chunk | grep "scroll-zkvm-integration(chunk-circuit): total cycles = ")
+          echo "total_cycles=$output" >> $GITHUB_ENV
+
+      - name: Update PR Description
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const totalCycles = process.env.total_cycles;
+            const currentBody = context.payload.pull_request.body;
+
+            // Update the PR description with the total cycles
+            const newBody = `### Total Cycles (chunk-circuit)\n${totalCycles}\n\n${currentBody}`;
+            await github.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              body: newBody,
+            });

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ build-guest:
 
 clean-build-guest: clean-guest build-guest
 
+chunk-profiling:
+	GUEST_PROFILING=true @cargo test --release -p scroll-zkvm-integration --features scroll --test chunk_circuit guest_profiling -- --exact --nocapture
+
 test-execute-chunk:
 	@cargo test --release -p scroll-zkvm-integration --features scroll --test chunk_circuit test_execute -- --exact --nocapture
 

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ build-guest:
 
 clean-build-guest: clean-guest build-guest
 
-chunk-profiling:
-	GUEST_PROFILING=true @cargo test --release -p scroll-zkvm-integration --features scroll --test chunk_circuit guest_profiling -- --exact --nocapture
+profile-chunk:
+	@GUEST_PROFILING=true cargo test --release -p scroll-zkvm-integration --features scroll --test chunk_circuit guest_profiling -- --exact --nocapture
 
 test-execute-chunk:
 	@cargo test --release -p scroll-zkvm-integration --features scroll --test chunk_circuit test_execute -- --exact --nocapture

--- a/crates/integration/src/lib.rs
+++ b/crates/integration/src/lib.rs
@@ -88,8 +88,8 @@ pub trait ProverTester {
     /// Load the app config.
     fn load() -> eyre::Result<(PathBuf, AppConfig<SdkVmConfig>, PathBuf)> {
         let path_app_config = Path::new(Self::PATH_PROJECT_ROOT).join(FD_APP_CONFIG);
-        let path_assets = Path::new(Self::PATH_PROJECT_ROOT).join("openvm");
         let app_config = read_app_config(&path_app_config)?;
+        let path_assets = Path::new(Self::PATH_PROJECT_ROOT).join("openvm");
         let path_app_exe = path_assets.join(FD_APP_EXE);
         Ok((path_app_config, app_config, path_app_exe))
     }

--- a/crates/integration/tests/chunk_circuit.rs
+++ b/crates/integration/tests/chunk_circuit.rs
@@ -36,7 +36,10 @@ fn guest_profiling() -> eyre::Result<()> {
         .execute_guest(&stdin)?
         .ok_or(eyre::eyre!("execute_guest returned None"))?;
 
-    println!("total cycles = {:?}", total_cycles);
+    println!(
+        "scroll-zkvm-integration(chunk-circuit): total cycles = {:?}",
+        total_cycles
+    );
 
     Ok(())
 }

--- a/crates/integration/tests/chunk_circuit.rs
+++ b/crates/integration/tests/chunk_circuit.rs
@@ -18,7 +18,7 @@ fn test_execute() -> eyre::Result<()> {
 }
 
 #[test]
-fn test_profiling() -> eyre::Result<()> {
+fn guest_profiling() -> eyre::Result<()> {
     ChunkProverTester::setup()?;
 
     let (path_app_config, _, path_exe) = ChunkProverTester::load()?;
@@ -29,8 +29,6 @@ fn test_profiling() -> eyre::Result<()> {
         None,
         Default::default(),
     )?;
-
-    std::env::set_var("GUEST_PROFILING", "true");
 
     let task = ChunkProverTester::gen_proving_task()?;
     let stdin = task.build_guest_input()?;

--- a/crates/prover/src/prover/mod.rs
+++ b/crates/prover/src/prover/mod.rs
@@ -217,11 +217,10 @@ impl<Type: ProverType> Prover<Type> {
         let _agg_stark_pk = AGG_STARK_PROVING_KEY
             .get_or_init(|| AggStarkProvingKey::keygen(AggStarkConfig::default()));
 
-        Ok((
-            app_committed_exe,
-            Arc::new(app_pk),
-            [exe_commit, leaf_commit],
-        ))
+        Ok((app_committed_exe, Arc::new(app_pk), [
+            exe_commit,
+            leaf_commit,
+        ]))
     }
 
     /// Dump assets required to setup verifier-only mode.


### PR DESCRIPTION
### Motivation

Sometimes we may end up using an incorrect patch or set an incorrect config for OpenVM. As we add more features and support more EIPs/RIPs via `revm` and OpenVM extensions, it is important to monitor the total cycles taken to prove a single chunk (from `testdata`) to make sense of a possible config/patch issue.

The `profile-guest.yml` workflow will run every time the `build-guest`yml` workflow succeeds and adds the "total cycles" for the chunk-circuit in the PR's description for convenient review.