### PR TITLE
CI: improvements and new workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@
 .dockerignore
 
 Dockerfile
-Dockerfile.backup
 
 .output
 
@@ -18,6 +17,6 @@ docs
 
 *.md
 
-openvm-clippy
-
 target
+
+crates/build-guest/root_verifier.asm

--- a/.github/workflows/build-guest.yml
+++ b/.github/workflows/build-guest.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config --local user.name "GitHub Actions"
+          git config --local user.name "GitHub Actions Bot"
           git config --local user.email "actions@github.com"
 
       - name: Commit changes (commitments)
@@ -158,7 +158,7 @@ jobs:
           git add crates/verifier/src/commitments/bundle.rs
           git add crates/circuits/batch-circuit/src/child_commitments.rs
           git add crates/circuits/bundle-circuit/src/child_commitments.rs
-          git commit -m "[Automated commit] chore: update commitments" || echo "No changes to commit"
+          git commit -m "[Automated] chore: update commitments" || echo "No changes to commit"
           echo "COMMIT_REF=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Push changes (commitments)
@@ -172,10 +172,17 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
+          aws-bucket: ${{ secrets.AWS_BUCKET }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Upload file to S3
         run: |
-          aws s3 cp crates/circuits/chunk-circuit/openvm/app.vmexe s3://circuit-release/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/chunk/app.vmexe
-          aws s3 cp crates/circuits/batch-circuit/openvm/app.vmexe s3://circuit-release/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/batch/app.vmexe
-          aws s3 cp crates/circuits/bundle-circuit/openvm/app.vmexe s3://circuit-release/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/bundle/app.vmexe
+          aws s3 cp crates/circuits/chunk-circuit/openvm/app.vmexe s3://${{ secrets.AWS_BUCKET }}/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/chunk/app.vmexe
+          aws s3 cp crates/circuits/batch-circuit/openvm/app.vmexe s3://${{ secrets.AWS_BUCKET }}/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/batch/app.vmexe
+          aws s3 cp crates/circuits/bundle-circuit/openvm/app.vmexe s3://${{ secrets.AWS_BUCKET }}/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/bundle/app.vmexe
+      
+      - name: Upload artifact (chunk app.vmexe)
+        uses: actions/upload-artifact@v4
+        with:
+          name: chunk-app-vmexe
+          path: ./crates/circuits/chunk-circuit/openvm/app.vmexe

--- a/.github/workflows/build-guest.yml
+++ b/.github/workflows/build-guest.yml
@@ -177,11 +177,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Upload app exe to s3
+      - name: Upload assets to s3
         run: |
           aws s3 cp crates/circuits/chunk-circuit/openvm/app.vmexe s3://circuit-release/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/chunk/app.vmexe
           aws s3 cp crates/circuits/batch-circuit/openvm/app.vmexe s3://circuit-release/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/batch/app.vmexe
           aws s3 cp crates/circuits/bundle-circuit/openvm/app.vmexe s3://circuit-release/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/bundle/app.vmexe
+          aws s3 cp crates/build-guest/root_verifier.asm s3://circuit-release/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/root_verifier.asm
       
       - name: Upload artifact (chunk app.vmexe)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-guest.yml
+++ b/.github/workflows/build-guest.yml
@@ -1,6 +1,7 @@
 name: Build Guest
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
     branches:
@@ -12,6 +13,7 @@ on:
       - crates/circuits/batch-circuit/**/*
       - crates/circuits/bundle-circuit/**/*
       - crates/build-guest/**/*
+      - Cargo.lock
   push:
     branches:
       - master
@@ -22,6 +24,7 @@ on:
       - crates/circuits/batch-circuit/**/*
       - crates/circuits/bundle-circuit/**/*
       - crates/build-guest/**/*
+      - Cargo.lock
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -172,17 +175,34 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-bucket: ${{ secrets.AWS_BUCKET }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Upload file to S3
+      - name: Upload app exe to s3
         run: |
-          aws s3 cp crates/circuits/chunk-circuit/openvm/app.vmexe s3://${{ secrets.AWS_BUCKET }}/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/chunk/app.vmexe
-          aws s3 cp crates/circuits/batch-circuit/openvm/app.vmexe s3://${{ secrets.AWS_BUCKET }}/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/batch/app.vmexe
-          aws s3 cp crates/circuits/bundle-circuit/openvm/app.vmexe s3://${{ secrets.AWS_BUCKET }}/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/bundle/app.vmexe
+          aws s3 cp crates/circuits/chunk-circuit/openvm/app.vmexe s3://circuit-release/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/chunk/app.vmexe
+          aws s3 cp crates/circuits/batch-circuit/openvm/app.vmexe s3://circuit-release/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/batch/app.vmexe
+          aws s3 cp crates/circuits/bundle-circuit/openvm/app.vmexe s3://circuit-release/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/bundle/app.vmexe
       
       - name: Upload artifact (chunk app.vmexe)
         uses: actions/upload-artifact@v4
         with:
           name: chunk-app-vmexe
           path: ./crates/circuits/chunk-circuit/openvm/app.vmexe
+
+      - name: Upload artifact (batch app.vmexe)
+        uses: actions/upload-artifact@v4
+        with:
+          name: batch-app-vmexe
+          path: ./crates/circuits/batch-circuit/openvm/app.vmexe
+
+      - name: Upload artifact (bundle app.vmexe)
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundle-app-vmexe
+          path: ./crates/circuits/bundle-circuit/openvm/app.vmexe
+
+      - name: Upload artifact (root verifier)
+        uses: actions/upload-artifact@v4
+        with:
+          name: root-verifier-asm
+          path: ./crates/build-guest/root_verifier.asm

--- a/.github/workflows/build-guest.yml
+++ b/.github/workflows/build-guest.yml
@@ -141,4 +141,41 @@ jobs:
         run: |
           make build-guest
           git diff
-          git diff --quiet && echo "no diff" || (echo "diff"; exit 1)
+
+      - name: Configure Git
+        run: |
+          git config --local user.name "GitHub Actions"
+          git config --local user.email "actions@github.com"
+
+      - name: Commit changes (commitments)
+        id: commit-commitments
+        run: |
+          git add crates/prover/src/commitments/chunk.rs
+          git add crates/prover/src/commitments/batch.rs
+          git add crates/prover/src/commitments/bundle.rs
+          git add crates/verifier/src/commitments/chunk.rs
+          git add crates/verifier/src/commitments/batch.rs
+          git add crates/verifier/src/commitments/bundle.rs
+          git add crates/circuits/batch-circuit/src/child_commitments.rs
+          git add crates/circuits/bundle-circuit/src/child_commitments.rs
+          git commit -m "[Automated commit] chore: update commitments" || echo "No changes to commit"
+          echo "COMMIT_REF=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Push changes (commitments)
+        run: |
+          git push origin ${{ github.head_ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up AWS CLI
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Upload file to S3
+        run: |
+          aws s3 cp crates/circuits/chunk-circuit/openvm/app.vmexe s3://circuit-release/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/chunk/app.vmexe
+          aws s3 cp crates/circuits/batch-circuit/openvm/app.vmexe s3://circuit-release/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/batch/app.vmexe
+          aws s3 cp crates/circuits/bundle-circuit/openvm/app.vmexe s3://circuit-release/scroll-zkvm/${{ steps.commit-commitments.outputs.COMMIT_REF }}/bundle/app.vmexe

--- a/.github/workflows/profile-guest.yml
+++ b/.github/workflows/profile-guest.yml
@@ -1,0 +1,49 @@
+name: Profile Guest
+
+on:
+  workflow_run:
+    workflows: ["Build Guest"]
+    types:
+      - completed
+
+jobs:
+  profile-guest:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download artifact (chunk app.vmexe)
+        uses: actions/download-artifact@v4
+        with:
+          name: chunk-app-vmexe
+          path: ./crates/circuits/chunk-circuit/openvm/
+
+      - name: Setup rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-12-06
+
+      - name: Guest profiling to capture total_cycles
+        id: guest-profiling
+        run: |
+          # Run the tests and capture the output
+          # TODO: enable later
+          # output=$(make profile-chunk | grep "scroll-zkvm-integration(chunk-circuit): total cycles = ")
+          output="Dummy Profiling Result"
+          echo "total_cycles=$output" >> $GITHUB_ENV
+
+      - name: Update PR Description
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const totalCycles = process.env.total_cycles;
+            const comment = context.payload.pull_request.body;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `<!--Benchmark Results-->\n${comment}`
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,3 +102,10 @@ jobs:
           SCROLL_ZKVM_VERSION=${{ github.event.inputs.version }}
           SCROLL_ZKVM_TESTRUN_DIR=${{ steps.guest-profiling.outputs.testrun_dir }}
         run: sh release.sh
+      
+      - name: Create GitHub Tag
+        run: |
+          git tag v${{ github.event.inputs.version }}
+          git push origin v${{ github.event.inputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version
+        required: true
+
+jobs:
+  dispatch-build-guest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Trigger Build Guest
+        id: trigger_build_guest
+        run: |
+          response=$(curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/build-guest.yml/dispatches \
+            -d '{"ref": "${{ github.ref }}"}')
+          echo "Response: $response"
+
+      - name: Check First Workflow Status
+        id: check_status
+        run: |
+          sleep 60
+          workflow_run_id=$(echo $response | jq -r '.id')
+          status=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/actions/runs/$workflow_run_id | jq -r '.status')
+          conclusion=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/actions/runs/$workflow_run_id | jq -r '.conclusion')
+
+          echo "Build Guest Status: $status"
+          echo "Build Guest Conclusion: $conclusion"
+
+          if [[ "$conclusion" != "success" ]]; then
+            echo "Build Guest did not succeed. Exiting."
+            exit 1
+          fi
+
+  run-e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-12-06
+
+      - name: Download artifact (chunk app.vmexe)
+        uses: actions/download-artifact@v4
+        with:
+          name: chunk-app-vmexe
+          path: ./crates/circuits/chunk-circuit/openvm/
+
+      - name: Download artifact (batch app.vmexe)
+        uses: actions/download-artifact@v4
+        with:
+          name: batch-app-vmexe
+          path: ./crates/circuits/batch-circuit/openvm/
+
+      - name: Download artifact (bundle app.vmexe)
+        uses: actions/download-artifact@v4
+        with:
+          name: bundle-app-vmexe
+          path: ./crates/circuits/bundle-circuit/openvm/
+
+      - name: Download artifact (root verifier)
+        uses: actions/download-artifact@v4
+        with:
+          name: root-verifier-asm
+          path: ./crates/build-guest/
+
+      - name: Run
+        id: guest-profiling
+        env:
+          VERSION=${{ github.event.inputs.version }}
+        run: |
+          make e2e-release
+          echo "testrun_dir=$(ls -d .output/*/ | head -n 1 | xargs -I {} basename {})" >> $GITHUB_OUTPUT
+
+      - name: Configure AWS CLI
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Upload to AWS s3
+        if: success()
+        env:
+          SCROLL_ZKVM_VERSION=${{ github.event.inputs.version }}
+          SCROLL_ZKVM_TESTRUN_DIR=${{ steps.guest-profiling.outputs.testrun_dir }}
+        run: sh release.sh

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /releases
 
 *.log
+
 root_verifier.asm

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ export RUST_LOG
 download-release:
 	sh download-release.sh
 
+download-artifacts:
+	sh download-artifacts.sh
+
 fmt:
 	@cargo fmt --all
 

--- a/build-guest.sh
+++ b/build-guest.sh
@@ -27,6 +27,6 @@ mkdir -p crates/circuits/bundle-circuit/openvm
 docker cp build-guest:/app/crates/circuits/chunk-circuit/openvm/app.vmexe crates/circuits/chunk-circuit/openvm/app.vmexe
 docker cp build-guest:/app/crates/circuits/batch-circuit/openvm/app.vmexe crates/circuits/batch-circuit/openvm/app.vmexe
 docker cp build-guest:/app/crates/circuits/bundle-circuit/openvm/app.vmexe crates/circuits/bundle-circuit/openvm/app.vmexe
-#docker cp build-guest:/app/crates/circuits/chunk-circuit/openvm/openvm.toml crates/circuits/chunk-circuit/openvm/openvm.toml
-#docker cp build-guest:/app/crates/circuits/batch-circuit/openvm/openvm.toml crates/circuits/batch-circuit/openvm/openvm.toml
-#docker cp build-guest:/app/crates/circuits/bundle-circuit/openvm/openvm.toml crates/circuits/bundle-circuit/openvm/openvm.toml
+
+# copy the root-verifier from container to local
+docker cp build-guest:/app/crates/build-guest/root_verifier.asm crates/build-guest/root_verifier.asm

--- a/download-artifacts.sh
+++ b/download-artifacts.sh
@@ -14,3 +14,6 @@ wget https://circuit-release.s3.us-west-2.amazonaws.com/scroll-zkvm/$COMMIT_REF/
 
 # bundle-circuit exe
 wget https://circuit-release.s3.us-west-2.amazonaws.com/scroll-zkvm/$COMMIT_REF/bundle/app.vmexe -O crates/circuits/bundle-circuit/openvm/app.vmexe
+
+# root verifier
+wget https://circuit-release.s3.us-west-2.amazonaws.com/scroll-zkvm/$COMMIT_REF/root_verifier.asm -O crates/build-guest/root_verifier.asm

--- a/download-artifacts.sh
+++ b/download-artifacts.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# release version
+if [ -z "${COMMIT_REF}" ]; then
+  echo "COMMIT_REF not set => get HEAD"
+  COMMIT_REF=$(git rev-parse HEAD)
+fi
+
+# chunk-circuit exe
+wget https://circuit-release.s3.us-west-2.amazonaws.com/scroll-zkvm/$COMMIT_REF/chunk/app.vmexe -O crates/circuits/chunk-circuit/openvm/app.vmexe
+
+# batch-circuit exe
+wget https://circuit-release.s3.us-west-2.amazonaws.com/scroll-zkvm/$COMMIT_REF/batch/app.vmexe -O crates/circuits/batch-circuit/openvm/app.vmexe
+
+# bundle-circuit exe
+wget https://circuit-release.s3.us-west-2.amazonaws.com/scroll-zkvm/$COMMIT_REF/bundle/app.vmexe -O crates/circuits/bundle-circuit/openvm/app.vmexe


### PR DESCRIPTION
- `Build Guest`
    - builds the guest programs in a docker container
    - commits the new commitments and pushes them (so the dev does not need to do this locally)
    - uploads the `app.vmexe` for all circuits to AWS s3 `{BUCKET}/{COMMIT_REF}/chunk/app.vmexe` and so on
    - uploads the chunk circuit's `app.vmexe` for use in the next workflow
- `Profile Guest`
    - fetches the chunk circuit's `app.vmexe` from the previous workflow
    - runs the guest-profiling test to get the number of cycles
    - posts a comment to the pull-request with the stats
- `Release` (manual trigger required)
    - builds guest `Build Guest`
    - downloads artifacts (exe + root verifier)
    - runs `test-e2e-bundle`
    - publishes a release