### PR TITLE
[Feat]auto cleanning for docker build

### DIFF
--- a/build-guest.sh
+++ b/build-guest.sh
@@ -4,15 +4,17 @@
 docker build --platform linux/amd64 -t build-guest:local .
 
 # run docker image
-docker run --platform linux/amd64 --name build-guest -e FEATURE=${FEATURE} build-guest:local
+docker run --cidfile ./build-guest.cid --platform linux/amd64 -e FEATURE=${FEATURE} build-guest:local
+container_id=$(cat ./build-guest.cid)
+rm ./build-guest.cid
 
 # copy commitments from container to local (prover)
-docker cp build-guest:/app/crates/prover/src/commitments/chunk.rs crates/prover/src/commitments/chunk.rs
-docker cp build-guest:/app/crates/prover/src/commitments/batch.rs crates/prover/src/commitments/batch.rs
-docker cp build-guest:/app/crates/prover/src/commitments/bundle.rs crates/prover/src/commitments/bundle.rs
-docker cp build-guest:/app/crates/prover/src/commitments/chunk_legacy.rs crates/prover/src/commitments/chunk_legacy.rs
-docker cp build-guest:/app/crates/prover/src/commitments/batch_legacy.rs crates/prover/src/commitments/batch_legacy.rs
-docker cp build-guest:/app/crates/prover/src/commitments/bundle_legacy.rs crates/prover/src/commitments/bundle_legacy.rs
+docker cp ${container_id}:/app/crates/prover/src/commitments/chunk.rs crates/prover/src/commitments/chunk.rs
+docker cp ${container_id}:/app/crates/prover/src/commitments/batch.rs crates/prover/src/commitments/batch.rs
+docker cp ${container_id}:/app/crates/prover/src/commitments/bundle.rs crates/prover/src/commitments/bundle.rs
+docker cp ${container_id}:/app/crates/prover/src/commitments/chunk_legacy.rs crates/prover/src/commitments/chunk_legacy.rs
+docker cp ${container_id}:/app/crates/prover/src/commitments/batch_legacy.rs crates/prover/src/commitments/batch_legacy.rs
+docker cp ${container_id}:/app/crates/prover/src/commitments/bundle_legacy.rs crates/prover/src/commitments/bundle_legacy.rs
 
 # copy commitments to local (verifier)
 cp crates/prover/src/commitments/chunk.rs crates/verifier/src/commitments/chunk.rs
@@ -32,6 +34,7 @@ cp crates/prover/src/commitments/batch_legacy.rs crates/circuits/bundle-circuit/
 mkdir -p crates/circuits/chunk-circuit/openvm
 mkdir -p crates/circuits/batch-circuit/openvm
 mkdir -p crates/circuits/bundle-circuit/openvm
-docker cp build-guest:/app/crates/circuits/chunk-circuit/openvm/app.vmexe crates/circuits/chunk-circuit/openvm/app.vmexe
-docker cp build-guest:/app/crates/circuits/batch-circuit/openvm/app.vmexe crates/circuits/batch-circuit/openvm/app.vmexe
-docker cp build-guest:/app/crates/circuits/bundle-circuit/openvm/app.vmexe crates/circuits/bundle-circuit/openvm/app.vmexe
+docker cp ${container_id}:/app/crates/circuits/chunk-circuit/openvm/app.vmexe crates/circuits/chunk-circuit/openvm/app.vmexe
+docker cp ${container_id}:/app/crates/circuits/batch-circuit/openvm/app.vmexe crates/circuits/batch-circuit/openvm/app.vmexe
+docker cp ${container_id}:/app/crates/circuits/bundle-circuit/openvm/app.vmexe crates/circuits/bundle-circuit/openvm/app.vmexe
+docker rm ${container_id}


### PR DESCRIPTION
docker build script use dynamic container name so we do not need to remove the `build-guest` container manually.