### PR TITLE
[refactor] Always check program commitment in each proof generation

### DIFF
--- a/crates/integration/tests/bundle_circuit.rs
+++ b/crates/integration/tests/bundle_circuit.rs
@@ -84,12 +84,15 @@ fn e2e() -> eyre::Result<()> {
     )?;
 
     // Verifier all above proofs with the verifier-only mode.
+    let verifier = verifier.to_chunk_verifier();
     for proof in chunk_proofs.iter() {
         assert!(verifier.verify_proof(proof.as_proof()));
     }
+    let verifier = verifier.to_batch_verifier();
     for proof in bundle_task.batch_proofs.iter() {
         assert!(verifier.verify_proof(proof.as_proof()));
     }
+    let verifier = verifier.to_bundle_verifier();
     assert!(verifier.verify_proof_evm(&outcome.proofs[0].as_proof()));
 
     let expected_pi_hash = &outcome.proofs[0].metadata.bundle_pi_hash;

--- a/crates/verifier/src/verifier.rs
+++ b/crates/verifier/src/verifier.rs
@@ -82,6 +82,25 @@ impl<Type> Verifier<Type> {
             _type: PhantomData,
         })
     }
+
+    pub fn switch_to<AnotherType>(self) -> Verifier<AnotherType> {
+        Verifier::<AnotherType> {
+            vm_executor: self.vm_executor,
+            root_committed_exe: self.root_committed_exe,
+            evm_verifier: self.evm_verifier,
+            _type: PhantomData,
+        }
+    }
+
+    pub fn to_chunk_verifier(self) -> ChunkVerifier {
+        self.switch_to()
+    }
+    pub fn to_batch_verifier(self) -> BatchVerifier {
+        self.switch_to()
+    }
+    pub fn to_bundle_verifier(self) -> BundleVerifier {
+        self.switch_to()
+    }
 }
 
 impl<Type: VerifierType> Verifier<Type> {


### PR DESCRIPTION
We can only get program commitment by `AppExecutionCommit::compute` route (or launch a verifcation progress)

This PR make sanity check by compute thie commitment every time a proof (snark or stark) is generated.