### PR TITLE
Feat: use default feature for `openvm-stark-sdk`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", rev = "f1b4844"
 openvm-sha256-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "f1b4844", default-features = false }
 openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "f1b4844", default-features = false }
 
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "bc364134b8315c27bfd29c6e77ac79fe77090137", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "bc364134b8315c27bfd29c6e77ac79fe77090137" }
 
 alloy-primitives = { version = "0.8", default-features = false }
 alloy-serde = { version = "0.8", default-features = false }


### PR DESCRIPTION
## Summary

In order to allow us to patch `openvm-stark-sdk` by the GPU variant, we need to cherry-pick #63 into `release/0.1.1-rc.2` as well.