### PR TITLE
Always check program commitment in each proof generation

### DIFF
--- a/crates/prover/src/prover/mod.rs
+++ b/crates/prover/src/prover/mod.rs
@@ -196,18 +196,18 @@ impl<Type: ProverType> Prover<Type> {
         if debug_out {
             debug!(name: "exe-commitment", prover_name = Type::NAME, raw = ?exe_commit, as_bn254 = ?commits.exe_commit_to_bn254());
             debug!(name: "leaf-commitment", prover_name = Type::NAME, raw = ?leaf_commit, as_bn254 = ?commits.app_config_commit_to_bn254());
+        } else {
+            assert_eq!(
+                exe_commit,
+                Type::EXE_COMMIT,
+                "read unmatched exe commitment from app"
+            );
+            assert_eq!(
+                leaf_commit,
+                Type::LEAF_COMMIT,
+                "read unmatched app commitment from app"
+            );
         }
-
-        assert_eq!(
-            exe_commit,
-            Type::EXE_COMMIT,
-            "read unmatched exe commitment from app"
-        );
-        assert_eq!(
-            leaf_commit,
-            Type::LEAF_COMMIT,
-            "read unmatched app commitment from app"
-        );
 
         [exe_commit, leaf_commit]
     }

--- a/crates/prover/src/utils.rs
+++ b/crates/prover/src/utils.rs
@@ -105,3 +105,20 @@ pub mod as_base64 {
         bincode::deserialize(&v_bytes).map_err(serde::de::Error::custom)
     }
 }
+
+use snark_verifier_sdk::snark_verifier::halo2_base::halo2_proofs::halo2curves::bn256::Fr;
+
+/// use the openvm's implement for compress 8xbabybear into bn254
+pub fn compress_commitment(commitment: &[u32; 8]) -> Fr {
+    use openvm_stark_sdk::{openvm_stark_backend::p3_field::PrimeField32, p3_baby_bear::BabyBear};
+    let order = Fr::from(BabyBear::ORDER_U32 as u64);
+    let mut base = Fr::one();
+    let mut ret = Fr::zero();
+
+    for v in commitment {
+        ret += Fr::from(*v as u64) * base;
+        base *= order;
+    }
+
+    ret
+}


### PR DESCRIPTION
This PR continue #75 and add sanity check for generated proof for its commitment, according to the review:

https://github.com/scroll-tech/zkvm-prover/pull/75#discussion_r1989391139