### PR TITLE
Fix typo

### DIFF
--- a/crates/build-guest/src/verifier/io_converter.rs
+++ b/crates/build-guest/src/verifier/io_converter.rs
@@ -5,7 +5,7 @@ use p3_field::FieldAlgebra;
 
 use super::asm_utils::*;
 
-// This function assumes the pi is published in sequencial order
+// This function assumes the pi is published in sequential order
 // `convert_publish_v1` was a more general version, but now `castf` cannot write to register,
 // so I have to use the `idx` here.
 pub fn convert_publish(op: Instruction<F>, idx: usize) -> Vec<Instruction<F>> {

--- a/crates/circuits/types/src/chunk/public_inputs.rs
+++ b/crates/circuits/types/src/chunk/public_inputs.rs
@@ -173,7 +173,7 @@ pub struct ChunkInfo {
     #[rkyv()]
     pub withdraw_root: B256,
     /// Digest of L1 message txs force included in the chunk.
-    /// It is a legacy field and can be omitted in new defination
+    /// It is a legacy field and can be omitted in new definition
     #[rkyv()]
     #[serde(default)]
     pub data_hash: B256,

--- a/crates/prover/src/task/batch.rs
+++ b/crates/prover/src/task/batch.rs
@@ -19,7 +19,7 @@ use crate::{
 /// Define variable batch header type, since BatchHeaderV6 can not
 /// be decoded as V7 we can always has correct deserialization
 /// Notice: V6 header MUST be put above V7 since untagged enum
-/// try to decode each defination in order
+/// try to decode each definition in order
 #[derive(Clone, serde::Deserialize, serde::Serialize)]
 #[serde(untagged)]
 pub enum BatchHeaderV {


### PR DESCRIPTION
This PR fixes a consistent typo where "defination" was incorrectly used instead of "definition" in comments across multiple files:

- crates/build-guest/src/verifier/io_converter.rs
- crates/circuits/types/src/chunk/public_inputs.rs
- crates/prover/src/task/batch.rs

No functional changes, just improving code readability and correctness.