### PR TITLE
fix unittest in type-batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3793,6 +3793,7 @@ version = "1.3.0-rc.1"
 source = "git+https://github.com/openvm-org/openvm.git?rev=3c800070d363237832a66dbe5501d3c365f3c549#3c800070d363237832a66dbe5501d3c365f3c549"
 dependencies = [
  "group 0.13.0",
+ "halo2curves-axiom 0.7.0",
  "hex-literal",
  "itertools 0.14.0",
  "num-bigint 0.4.6",

--- a/crates/types/batch/Cargo.toml
+++ b/crates/types/batch/Cargo.toml
@@ -18,7 +18,7 @@ types-base = { path = "../base", package = "scroll-zkvm-types-base" }
 openvm = { workspace = true, features = ["std"] }
 openvm-ecc-guest = { workspace = true, features = ["halo2curves"] }
 openvm-pairing-guest = { workspace = true, features = ["halo2curves"] }
-openvm-pairing = { workspace = true, features = ["bls12_381"] }
+openvm-pairing = { workspace = true, features = ["bls12_381", "halo2curves"] }
 openvm-sha2.workspace = true
 openvm-sha256-guest.workspace = true
 halo2curves-axiom = "0.7.0"


### PR DESCRIPTION
Currently the unittest in `types/batch` is failed, caused by feature setting in dependencies:
https://github.com/scroll-tech/zkvm-prover/blob/09e998fa90451006ba6f3a32d612bdeb02527384/crates/types/batch/Cargo.toml#L20-L21

Without "halo2curves" set in `openvm-pairing` the corresponding feature set in `openvm-pairing-guest` (since `openvm-pairing` depend on it) is also disabled.