### PR TITLE
update guest stdin building for universal task

### DIFF
--- a/crates/prover/src/task/mod.rs
+++ b/crates/prover/src/task/mod.rs
@@ -35,7 +35,11 @@ impl ProvingTask for UniversalProvingTask {
         }
 
         for proof in &self.aggregated_proofs {
-            let streams = proof.write();
+            let streams = if self.fork_name() >= ForkName::Feynman {
+                proof.proofs[0].write()
+            } else {
+                proof.write()
+            };
             for s in &streams {
                 stdin.write_field(s);
             }


### PR DESCRIPTION
The update for generated stdin in batch/bundle task is not applied into universal task.

This PR applied same updates to universal task.