### PR TITLE
Fix batch header v

### DIFF
--- a/crates/integration/src/utils/mod.rs
+++ b/crates/integration/src/utils/mod.rs
@@ -85,8 +85,7 @@ impl From<&BatchHeaderV> for LastHeader {
     fn from(value: &BatchHeaderV) -> Self {
         match value {
             BatchHeaderV::V6(h) => h.into(),
-            BatchHeaderV::V7(h) => h.into(),
-            BatchHeaderV::V8(h) => h.into(),
+            BatchHeaderV::V7_8(h) => h.into(),
         }
     }
 }
@@ -293,7 +292,7 @@ pub fn build_batch_task(
         ForkName::EuclidV2 => {
             use scroll_zkvm_types::batch::BatchHeaderV7;
             let _ = x + z;
-            BatchHeaderV::V7(BatchHeaderV7 {
+            BatchHeaderV::V7_8(BatchHeaderV7 {
                 version: last_header.version,
                 batch_index: last_header.batch_index + 1,
                 parent_batch_hash: last_header.batch_hash,
@@ -303,7 +302,7 @@ pub fn build_batch_task(
         ForkName::Feynman => {
             use scroll_zkvm_types::batch::BatchHeaderV8;
             let _ = x + z;
-            BatchHeaderV::V8(BatchHeaderV8 {
+            BatchHeaderV::V7_8(BatchHeaderV8 {
                 version: last_header.version,
                 batch_index: last_header.batch_index + 1,
                 parent_batch_hash: last_header.batch_hash,

--- a/crates/prover/src/task/batch.rs
+++ b/crates/prover/src/task/batch.rs
@@ -164,7 +164,11 @@ impl ProvingTask for BatchProvingTask {
             kzg_proof: kzg_proof.into_inner(),
         };
 
-        let reference_header = self.batch_header.clone().into();
+        let reference_header = match fork_name {
+            ForkName::EuclidV1 => ReferenceHeader::V6(*self.batch_header.must_v6_header()),
+            ForkName::EuclidV2 => ReferenceHeader::V7(*self.batch_header.must_v7_header()),
+            ForkName::Feynman => ReferenceHeader::V8(*self.batch_header.must_v8_header()),
+        };
 
         let witness = BatchWitness {
             fork_name,


### PR DESCRIPTION
The batch proving task's implementation for generating stdin for the zkvm had issues, that are being fixed here.

1. since both `BatchHeaderV8` and `BatchHeaderV7` essentially refer to the same type, deserialising batch header always gave us `BatchHeaderV7`.
2. the same with reference header

Upon fixing the above 2, a Feynman task can now be executed