### PR TITLE
[Fix] Fix s3 release dir in build-guest-release.yml

### DIFF
--- a/.github/workflows/build-guest-release.yml
+++ b/.github/workflows/build-guest-release.yml
@@ -59,4 +59,4 @@ jobs:
 
       - name: Upload releases to S3
         run: |
-          aws s3 cp $DIR_OUTPUT s3://circuit-release/scroll-zkvm --recursive
+          aws s3 cp $DIR_OUTPUT s3://circuit-release/scroll-zkvm/releases --recursive


### PR DESCRIPTION
Resume the missed "release" path in s3