### PR TITLE
fix: script for paths with spaces

### DIFF
--- a/scripts/compile-solidity.sh
+++ b/scripts/compile-solidity.sh
@@ -1,3 +1,4 @@
-echo $1 -> $2
+#!/bin/bash
+echo "$1 -> $2"
 # version: solc-linux-amd64-v0.8.19+commit.7dd6d404
-cat $1 | solc --bin - | grep 6080 | xxd -r -p > $2
+solc --bin "$1" | grep 6080 | xxd -r -p > "$2"


### PR DESCRIPTION
wrapped `$1` and `$2` in quotes so spaces don’t break things,
dropped the unnecessary `cat`, and added `#!/bin/bash` at the top.