### PR TITLE
Update tag patterns for guest release workflow

### DIFF
--- a/.github/workflows/build-guest-release.yml
+++ b/.github/workflows/build-guest-release.yml
@@ -3,7 +3,8 @@ name: Build ZKVM-Prover Guest
 on:
   push:
     tags:
-      - 'v0.[0-9]+.[0-9]+(-.*)?'
+      - 'v0.[0-9]+.[0-9]+'
+      - 'v0.[0-9]+.[0-9]+-*'
 
 jobs:
   build-guest:


### PR DESCRIPTION
Git action use its own pattern filter (similar to glob pattern) . This PR fix the `push.tags` directive