### PR TITLE
[FEAT] Action with access to openvm private repo

### DIFF
--- a/.github/workflows/build-guest-release.yml
+++ b/.github/workflows/build-guest-release.yml
@@ -29,6 +29,11 @@ jobs:
           components: rust-src
           override: true
 
+      - name: Set up SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+            ssh-private-key: ${{ secrets.OPENVM_PRIVATE_DEPLOY_KEY }}
+
       - name: Cache cargo registry and build
         uses: actions/cache@v4
         with:
@@ -39,7 +44,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build guest binary
-        run: make build-guest 
+        run: make build-guest
         
       - name: Prepare release
         run: sh release.sh

--- a/.github/workflows/build-guest.yml
+++ b/.github/workflows/build-guest.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+            ssh-private-key: ${{ secrets.OPENVM_PRIVATE_DEPLOY_KEY }}
+
       - name: Build guest and check diff
         run: |
           make build-guest     

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+            ssh-private-key: ${{ secrets.OPENVM_PRIVATE_DEPLOY_KEY }}
+
       - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
         with:
           toolchain: nightly-2025-08-18

--- a/.github/workflows/profile-guest.yml
+++ b/.github/workflows/profile-guest.yml
@@ -16,6 +16,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+            ssh-private-key: ${{ secrets.OPENVM_PRIVATE_DEPLOY_KEY }}
+
       - name: Download artifact (chunk app.vmexe)
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Add ssh agent setup to workflows to enable accessing to a private repo of openvm. This could make applying some updates can not be public at present (like security patches) convenient