### PR TITLE
feat: halo2-gpu support for SNARK proving on 24GB GPUs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ To move to a newer OpenVM tag, retarget every `openvm-org/openvm.git` and `openv
    # Docker build (matches CI)
    OPENVM_RUST_TOOLCHAIN=nightly-2025-11-20 make build-guest
    ```
-   This regenerates: `app.elf`, `app.vmexe`, commitment `.rs` files, `openVmVk.json`,
+   This regenerates: `app.elf`, `app.vmexe`, commitment `.rs` files, `agg_vk.bin`, `openVmVk.json`,
    and the EVM verifier (`verifier.sol` + `verifier.bin`).
 
    > The default `RECOMPUTE_MODE=auto` tries to download the Solidity verifier from
@@ -67,8 +67,9 @@ To move to a newer OpenVM tag, retarget every `openvm-org/openvm.git` and `openv
    These are cached proving keys. They are **not** automatically invalidated on version bumps.
 
 5. **Check SRS params** in `~/.openvm/params/`:
-   - OpenVM v2.0.0 requires `kzg_bn254_24.srs` (2 GB)
-   - If the file is empty/corrupted, replace it (check for `.1` or `.part` suffixes from interrupted downloads)
+   - OpenVM v2.0.0 requires `kzg_bn254_24.srs` (2 GB); the SNARK step in e2e tests also needs `kzg_bn254_22.srs` and `kzg_bn254_23.srs`
+   - Download any missing file with `make $HOME/.openvm/params/<name>.srs`
+   - If a file is empty/corrupted, replace it (check for `.1` or `.part` suffixes from interrupted downloads)
 
 6. **Clear test output cache** before re-running integration tests:
    ```bash
@@ -112,6 +113,40 @@ OPENVM_RUST_TOOLCHAIN=nightly-2025-11-20 cargo run --release -p scroll-zkvm-buil
 
 ### Docker build fails with stale CID
 The `build-guest.sh` script may fail if a stale `build-guest.cid` file exists. Use local build (`cargo run -p scroll-zkvm-build-guest`) as fallback.
+
+## GPU Features
+
+Two levels of GPU acceleration exist, wired as cargo features:
+
+- `scroll-zkvm-integration/cuda` (→ `scroll-zkvm-prover/cuda` → `openvm-sdk/cuda`): STARK proving on GPU.
+- `scroll-zkvm-integration/halo2-gpu` (→ `openvm-sdk/halo2-gpu` → `openvm-static-verifier/halo2-gpu` → `snark-verifier-sdk/cuda`): additionally runs the **halo2 (SNARK) aggregation prover on GPU** via `halo2-axiom-gpu`. This needs far more VRAM than STARK proving — `test-e2e-bundle` peaks at ~23.5 GiB, so it only fits on 24 GB-class cards (e.g. RTX 3090/4090).
+
+The Makefile auto-enables `halo2-gpu` when `GPU=1` and the GPU has ≥ 22 GiB VRAM. Override with `HALO2_GPU=1` / `HALO2_GPU=0`:
+
+```bash
+GPU=1 make test-e2e-bundle        # 24 GB card: STARK + SNARK both on GPU
+GPU=1 HALO2_GPU=0 make test-e2e-bundle  # STARK on GPU, SNARK on CPU
+```
+
+### VRAM budgeting with `halo2-gpu` (24 GB cards)
+
+Measured on RTX 4090 during `test-e2e-bundle`:
+
+- The halo2 SNARK prover (k=23 static-verifier circuit) needs **~15 GB of physically free VRAM** at `create_proof` time (SRS upload, pk/advice polynomials, MSM buckets, NTT). These allocations are not chunkable; only the final quotient step chunks itself by `cudaMemGetInfo` free bytes.
+- openvm's VPMM memory pool (`openvm-cuda-common`) **never returns physical pages to the OS** — once the pool grows, `cudaMemGetInfo` free bytes stay low for the rest of the process. What matters is *live* GPU allocations at SNARK start.
+- If free bytes ≈ 0, the quotient chunking computes `batch_size = 0`, which surfaces as `cudaErrorInvalidConfiguration` (`quotient.cu`) or a SIGFPE (division by zero in MSM `win_num_`) — not a clean OOM.
+
+To keep the live GPU set small before the SNARK phase:
+
+- The aggregation VK is a **release asset** (`releases/dev/{chunk,batch,bundle}/agg_vk.bin`, written by build-guest). `Prover::load_agg_vk()` reads it; `enable_deferral`, `compute_deferral_data`, and the integration `get_agg_vk()` all use it instead of building the child's GPU aggregation prover (~5.7 GB per circuit) just to obtain the VK.
+- Integration `get_vk()` uses `PROGRAM_COMMITMENTS` (from `openVmVk.json`) instead of `Prover::get_app_vk()`, which also builds the GPU prover as a side effect.
+- The bundle tester calls `chunk_prover.reset()` / `batch_prover.reset()` after `enable_deferral` to drop child SDKs before SNARK.
+
+Do **not** reintroduce `sdk.prover()` / `sdk.agg_vk()` calls in read-only (verification/config) paths — each one silently uploads GiB-scale proving keys that stay live for the process lifetime.
+
+### Dependency note: `halo2-lib` retag
+
+`halo2-axiom-gpu` (pulled in by `snark-verifier-sdk/cuda`) must pin `openvm-cuda-common` to the **same stark-backend source** as the rest of the graph, or resolution fails with a `links = "cuda-common"` conflict. axiom-crypto **retagged `halo2-lib` v0.5.4** (commit `6522c1c5` → `a69fdee7`) to fix exactly this (`halo2-axiom-gpu` tag `v1.0.0-rc.2` → `v1.0.0`); the code diff is semantically nil. `Cargo.lock` is pinned to the new commit — if a stale lock ever resolves `halo2-axiom-gpu` to `v1.0.0-rc.2`, run `cargo update -p halo2-base` (scoped, safe) to re-resolve the moved tag.
 
 ## Build & Test Commands
 
@@ -170,6 +205,7 @@ If any of these mismatch, the EVM verifier will reject proofs with `ProofVerific
 | File / Dir | Purpose |
 |------------|---------|
 | `releases/dev/{chunk,batch,bundle}/app.vmexe` | Guest executables |
+| `releases/dev/{chunk,batch,bundle}/agg_vk.bin` | Serialized aggregation VK (read by `Prover::load_agg_vk`) |
 | `releases/dev/verifier/openVmVk.json` | Program commitments loaded by integration tests |
 | `releases/dev/verifier/verifier.bin` | EVM verifier bytecode |
 | `crates/circuits/*-circuit/openvm.toml` | Guest VM configs (FRI params, PoW bits) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ version = "0.9.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e713c57c2a2b19159e7be83b9194600d7e8eb3b7c2cd67e671adf47ce189a05"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cipher",
  "cpufeatures",
 ]
@@ -106,7 +106,8 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -371,7 +372,7 @@ checksum = "355bf68a433e0fd7f7d33d5a9fc2583fde70bf5c530f63b80845f8da5505cf28"
 dependencies = [
  "alloy-rlp",
  "bytes",
- "cfg-if",
+ "cfg-if 1.0.4",
  "const-hex",
  "derive_more 2.0.1",
  "foldhash 0.2.0",
@@ -1156,6 +1157,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "aurora-engine-modexp"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,7 +1207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "miniz_oxide",
  "object 0.37.3",
@@ -1291,6 +1303,12 @@ dependencies = [
  "bitcoin-io",
  "hex-conservative",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1579,6 +1597,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
@@ -1685,7 +1709,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "proptest",
  "serde_core",
@@ -1943,6 +1967,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-config"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee74643f7430213a1a78320f88649de309b20b80818325575e393f848f79f5d"
+dependencies = [
+ "glob",
+]
+
+[[package]]
+name = "cuda-driver-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d4c552cc0de854877d80bcd1f11db75d42be32962d72a6799b88dcca88fffbd"
+dependencies = [
+ "cuda-config",
+]
+
+[[package]]
 name = "cudarc"
 version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,7 +2067,7 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
@@ -2345,6 +2387,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,6 +2557,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2656,7 +2720,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -2676,7 +2740,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "wasi",
 ]
@@ -2687,7 +2751,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "r-efi",
@@ -2764,7 +2828,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-sink",
  "futures-timer",
  "futures-util",
@@ -2815,8 +2879,8 @@ dependencies = [
 
 [[package]]
 name = "halo2-axiom"
-version = "0.5.1"
-source = "git+https://github.com/axiom-crypto/halo2.git?tag=v0.5.1#c9e642dd14561274de4f6f11625aa3ae73ea74d0"
+version = "0.5.2"
+source = "git+https://github.com/axiom-crypto/halo2.git?tag=v0.5.2#1eed471495b64ec1edf22f0661bbc65d0e4381d5"
 dependencies = [
  "blake2b_simd",
  "crossbeam",
@@ -2835,12 +2899,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "halo2-axiom-gpu"
+version = "1.0.0"
+source = "git+https://github.com/axiom-crypto/halo2-gpu.git?tag=v1.0.0#97ef2d02aa3348fc04b520c3c2562a9c13b57126"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "ark-std 0.3.0",
+ "blake2b_simd",
+ "cfg-if 0.1.10",
+ "colored",
+ "crossbeam",
+ "cuda-driver-sys",
+ "env_logger",
+ "ff 0.13.1",
+ "git-version",
+ "group 0.13.0",
+ "halo2-axiom",
+ "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.11.0",
+ "lazy_static",
+ "libc",
+ "log",
+ "num-bigint",
+ "num-integer",
+ "once_cell",
+ "openvm-cuda-builder",
+ "openvm-cuda-common",
+ "pairing 0.23.0",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "rayon",
+ "rustacuda",
+ "rustc-hash 1.1.0",
+ "sha3",
+ "subtle",
+ "tracing",
+ "yastl",
+]
+
+[[package]]
 name = "halo2-base"
 version = "0.5.4"
-source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.5.4#6522c1c5fd98daf92cba36f97fecd00e59d5ad70"
+source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.5.4#a69fdee77f41bdd48ad658b69673dea5a0815db4"
 dependencies = [
  "getset",
  "halo2-axiom",
+ "halo2-axiom-gpu",
  "itertools 0.11.0",
  "log",
  "num-bigint",
@@ -2857,7 +2962,7 @@ dependencies = [
 [[package]]
 name = "halo2-ecc"
 version = "0.5.4"
-source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.5.4#6522c1c5fd98daf92cba36f97fecd00e59d5ad70"
+source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.5.4#a69fdee77f41bdd48ad658b69673dea5a0815db4"
 dependencies = [
  "halo2-base",
  "itertools 0.11.0",
@@ -2992,6 +3097,15 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -3083,6 +3197,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
 
 [[package]]
 name = "hybrid-array"
@@ -3448,7 +3571,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
@@ -3516,7 +3639,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "winapi",
 ]
 
@@ -3659,7 +3782,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "rayon",
 ]
 
@@ -3957,7 +4080,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
@@ -4012,7 +4135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4b5ecbd0beec843101bffe848217f770e8b8da81d8355b7d6e226f2199b3dc"
 dependencies = [
  "alloy-rlp",
- "cfg-if",
+ "cfg-if 1.0.4",
  "proptest",
  "ruint",
  "serde",
@@ -4025,7 +4148,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -4145,8 +4268,8 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags",
- "cfg-if",
+ "bitflags 2.10.0",
+ "cfg-if 1.0.4",
  "foreign-types",
  "libc",
  "openssl-macros",
@@ -4203,7 +4326,7 @@ version = "2.0.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v2.0.0#15a7ab6baed03d75050dbef2bbad4b4e98fb8dba"
 dependencies = [
  "blstrs",
- "cfg-if",
+ "cfg-if 1.0.4",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
@@ -4325,7 +4448,7 @@ name = "openvm-bigint-circuit"
 version = "2.0.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v2.0.0#15a7ab6baed03d75050dbef2bbad4b4e98fb8dba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "openvm-bigint-transpiler",
@@ -4391,7 +4514,7 @@ dependencies = [
  "abi_stable",
  "backtrace",
  "bytesize",
- "cfg-if",
+ "cfg-if 1.0.4",
  "dashmap",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4481,7 +4604,7 @@ name = "openvm-continuations"
 version = "2.0.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v2.0.0#15a7ab6baed03d75050dbef2bbad4b4e98fb8dba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "derivative",
  "derive-new 0.6.0",
  "eyre",
@@ -4512,7 +4635,7 @@ name = "openvm-cpu-backend"
 version = "2.0.0"
 source = "git+https://github.com/openvm-org/stark-backend.git?tag=v2.0.0#16d60de724c21dcadfde7d8315a1db507e5832d7"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "derive-new 0.7.0",
  "getset",
  "itertools 0.14.0",
@@ -4597,7 +4720,7 @@ name = "openvm-deferral-circuit"
 version = "2.0.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v2.0.0#15a7ab6baed03d75050dbef2bbad4b4e98fb8dba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "dashmap",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4653,7 +4776,7 @@ version = "2.0.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v2.0.0#15a7ab6baed03d75050dbef2bbad4b4e98fb8dba"
 dependencies = [
  "blstrs",
- "cfg-if",
+ "cfg-if 1.0.4",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
@@ -4864,7 +4987,7 @@ name = "openvm-pairing-circuit"
 version = "2.0.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v2.0.0#15a7ab6baed03d75050dbef2bbad4b4e98fb8dba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
@@ -5012,7 +5135,7 @@ name = "openvm-rv32im-circuit"
 version = "2.0.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v2.0.0#15a7ab6baed03d75050dbef2bbad4b4e98fb8dba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
@@ -5068,7 +5191,7 @@ source = "git+https://github.com/openvm-org/openvm.git?tag=v2.0.0#15a7ab6baed03d
 dependencies = [
  "alloy-sol-types",
  "bitcode",
- "cfg-if",
+ "cfg-if 1.0.4",
  "clap",
  "derivative",
  "derive-new 0.6.0",
@@ -5106,7 +5229,7 @@ version = "2.0.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v2.0.0#15a7ab6baed03d75050dbef2bbad4b4e98fb8dba"
 dependencies = [
  "bon",
- "cfg-if",
+ "cfg-if 1.0.4",
  "derive_more 1.0.0",
  "openvm-algebra-circuit",
  "openvm-algebra-transpiler",
@@ -5164,7 +5287,7 @@ name = "openvm-sha2-circuit"
 version = "2.0.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v2.0.0#15a7ab6baed03d75050dbef2bbad4b4e98fb8dba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "itertools 0.14.0",
@@ -5215,7 +5338,7 @@ name = "openvm-stark-backend"
 version = "2.0.0"
 source = "git+https://github.com/openvm-org/stark-backend.git?tag=v2.0.0#16d60de724c21dcadfde7d8315a1db507e5832d7"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "derivative",
  "derive-new 0.7.0",
  "eyre",
@@ -5319,7 +5442,7 @@ version = "2.0.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v2.0.0#15a7ab6baed03d75050dbef2bbad4b4e98fb8dba"
 dependencies = [
  "bitcode",
- "cfg-if",
+ "cfg-if 1.0.4",
  "derive-new 0.6.0",
  "eyre",
  "itertools 0.14.0",
@@ -5692,7 +5815,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -5891,7 +6014,7 @@ version = "0.7.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffd40cc99d0fbb02b4b3771346b811df94194bc103983efa0203c8893755085"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "universal-hash",
 ]
@@ -6050,7 +6173,7 @@ checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.10.0",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -6209,7 +6332,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -6244,7 +6367,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -6974,7 +7097,7 @@ version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cd508416a35a4d8a9feaf5ccd06ac6d6661cd31ee2dc0252f9f7316455d71f9"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "derive-where",
  "revm-bytecode 6.2.2",
  "revm-context-interface 9.0.0",
@@ -6991,7 +7114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a20c98e7008591a6f012550c2a00aa36cba8c14cc88eb88dec32eb9102554b4"
 dependencies = [
  "bitvec",
- "cfg-if",
+ "cfg-if 1.0.4",
  "derive-where",
  "revm-bytecode 6.2.2",
  "revm-context-interface 10.2.0",
@@ -7007,7 +7130,7 @@ version = "10.1.1"
 source = "git+https://github.com/scroll-tech/revm?tag=scroll-v91#10e11b985ed28bd383e624539868bcc3f613d77c"
 dependencies = [
  "bitvec",
- "cfg-if",
+ "cfg-if 1.0.4",
  "derive-where",
  "revm-bytecode 7.0.1",
  "revm-context-interface 11.1.1",
@@ -7024,7 +7147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7adcce0c14cf59b7128de34185a0fbf8f63309539b9263b35ead870d73584114"
 dependencies = [
  "bitvec",
- "cfg-if",
+ "cfg-if 1.0.4",
  "derive-where",
  "revm-bytecode 7.1.1",
  "revm-context-interface 11.1.2",
@@ -7386,7 +7509,7 @@ dependencies = [
  "aurora-engine-modexp",
  "blst",
  "c-kzg",
- "cfg-if",
+ "cfg-if 1.0.4",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1",
  "once_cell",
@@ -7413,7 +7536,7 @@ dependencies = [
  "aurora-engine-modexp",
  "blst",
  "c-kzg",
- "cfg-if",
+ "cfg-if 1.0.4",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1",
  "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7437,7 +7560,7 @@ dependencies = [
  "arrayref",
  "aurora-engine-modexp",
  "c-kzg",
- "cfg-if",
+ "cfg-if 1.0.4",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "revm-primitives 21.0.1",
@@ -7502,7 +7625,7 @@ version = "7.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f64fbacb86008394aaebd3454f9643b7d5a782bd251135e17c5b33da592d84d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "revm-bytecode 6.2.2",
  "revm-primitives 20.2.1",
  "serde",
@@ -7513,7 +7636,7 @@ name = "revm-state"
 version = "8.0.1"
 source = "git+https://github.com/scroll-tech/revm?tag=scroll-v91#10e11b985ed28bd383e624539868bcc3f613d77c"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "revm-bytecode 7.0.1",
  "revm-primitives 21.0.1",
  "serde",
@@ -7525,7 +7648,7 @@ version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8be953b7e374dbdea0773cf360debed8df394ea8d82a8b240a6b5da37592fc"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "revm-bytecode 7.1.1",
  "revm-primitives 21.0.2",
  "serde",
@@ -7632,6 +7755,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
+name = "rustacuda"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47208516ab5338b592d63560e90eaef405d0ec880347eaf7742d893b0a31e228"
+dependencies = [
+ "bitflags 1.3.2",
+ "cuda-driver-sys",
+ "rustacuda_core",
+ "rustacuda_derive",
+]
+
+[[package]]
+name = "rustacuda_core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3858b08976dc2f860c5efbbb48cdcb0d4fafca92a6ac0898465af16c0dbe848"
+
+[[package]]
+name = "rustacuda_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ce8670a1a1d0fc2514a3b846dacdb65646f9bd494b6674cfacbb4ce430bd7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7679,7 +7831,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -8271,7 +8423,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -8458,7 +8610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -8470,7 +8622,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -8505,7 +8657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -8634,6 +8786,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"
@@ -8676,7 +8831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "psm",
  "windows-sys 0.59.0",
@@ -8876,6 +9031,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "test-case"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8890,7 +9054,7 @@ version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "proc-macro2",
  "quote",
  "syn 2.0.110",
@@ -8954,7 +9118,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -9182,7 +9346,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http",
@@ -9507,7 +9671,7 @@ version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -9520,7 +9684,7 @@ version = "0.4.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -9608,6 +9772,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -9928,6 +10101,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "yastl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca6c5a4d66c1a9ea261811cf4773c27343de7e5033e1b75ea3f297dc7db3c1a"
+dependencies = [
+ "flume",
+ "scopeguard",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10056,7 +10239,7 @@ dependencies = [
  "blake2",
  "bls12_381",
  "byteorder",
- "cfg-if",
+ "cfg-if 1.0.4",
  "group 0.12.1",
  "group 0.13.0",
  "halo2",

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,27 @@ export OPENVM_RUST_TOOLCHAIN
 # Set GPU config if GPU=1 is set
 ifeq ($(GPU),1)
 CARGO_CONFIG_FLAG = --features scroll-zkvm-integration/cuda
+# SNARK (halo2) GPU proving needs ~15 GiB of free VRAM on top of the STARK
+# prover's footprint (test-e2e-bundle peaks at ~23.5 GiB), so auto-enable it
+# only on 24 GB-class cards (e.g. RTX 3090/4090). Override with HALO2_GPU=1 / HALO2_GPU=0.
+HALO2_GPU ?= auto
+ifeq ($(HALO2_GPU),1)
+HALO2_GPU_ENABLED := 1
+else ifeq ($(HALO2_GPU),auto)
+GPU_MEM_MIB := $(shell nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null | sort -rn | head -1)
+HALO2_GPU_ENABLED := $(shell [ -n "$(GPU_MEM_MIB)" ] && [ "$(GPU_MEM_MIB)" -ge 22000 ] && echo 1)
+endif
+ifneq ($(HALO2_GPU_ENABLED),)
+CARGO_CONFIG_FLAG += --features scroll-zkvm-integration/halo2-gpu
+$(info halo2 GPU proving enabled: SNARK aggregation will run on GPU)
+endif
 else
 CARGO_CONFIG_FLAG =
 endif
 
 SRS_PARAMS_DIR := $(HOME)/.openvm/params
 SRS_PARAMS_URL := https://circuit-release.s3.us-west-2.amazonaws.com/scroll-zkvm/params
-SRS_PARAMS := $(SRS_PARAMS_DIR)/kzg_bn254_22.srs $(SRS_PARAMS_DIR)/kzg_bn254_24.srs
+SRS_PARAMS := $(SRS_PARAMS_DIR)/kzg_bn254_22.srs $(SRS_PARAMS_DIR)/kzg_bn254_23.srs $(SRS_PARAMS_DIR)/kzg_bn254_24.srs
 
 # Download params if missing
 $(SRS_PARAMS_DIR)/%.srs:

--- a/crates/build-guest/src/main.rs
+++ b/crates/build-guest/src/main.rs
@@ -107,6 +107,9 @@ const LOG_PREFIX: &str = "[build-guest]";
 /// File descriptor for app openvm config.
 const FD_APP_CONFIG: &str = "openvm.toml";
 
+/// File descriptor for the serialized aggregation verifying key.
+const FD_AGG_VK: &str = "agg_vk.bin";
+
 /// Writes a commitment array to a Rust source file.
 fn write_commitment(output_path: &PathBuf, commitment: [u32; DIGEST_SIZE]) -> Result<()> {
     let content = format!(
@@ -351,6 +354,13 @@ fn generate_app_assets(workspace_dir: &Path, release_output_dir: &PathBuf) -> Re
         println!("{project_name}: {app_vk}");
 
         vk_dump[format!("{project_name}_vk")] = serde_json::Value::String(app_vk);
+
+        // Dump the aggregation VK so downstream provers can build deferral
+        // circuits and verify cached proofs without constructing the (GPU)
+        // aggregation prover just to obtain the VK.
+        let path_agg_vk = path_assets.join(FD_AGG_VK);
+        write_object_to_file(&path_agg_vk, sdk.agg_vk().clone())?;
+        println!("{LOG_PREFIX} agg vk written to {path_agg_vk:?}");
 
         println!(
             "{LOG_PREFIX} Finished build for config in {:?}",

--- a/crates/build-guest/src/main.rs
+++ b/crates/build-guest/src/main.rs
@@ -344,6 +344,15 @@ fn generate_app_assets(workspace_dir: &Path, release_output_dir: &PathBuf) -> Re
             write_commitment_as_evm_hex(&output_path, vm_commit_u32)?;
         }
 
+        // Write the aggregation VK for batch proofs so the coordinator can verify
+        // deferred batch proofs independently (v0.9.0+).
+        if project_name == "batch" {
+            let batch_mvk_path = release_output_dir.join("batch_root_verifier_vk");
+            write_object_to_file(&batch_mvk_path, sdk.agg_vk().clone())
+                .expect("failed to write batch_root_verifier_vk");
+            println!("{LOG_PREFIX} Wrote batch aggregation VK to {batch_mvk_path:?}");
+        }
+
         use scroll_zkvm_types::{types_agg::ProgramCommitment, utils::serialize_vk};
         let app_vk = serialize_vk::serialize(&ProgramCommitment {
             exe: exe_commit_u32,

--- a/crates/integration/Cargo.toml
+++ b/crates/integration/Cargo.toml
@@ -72,5 +72,7 @@ glob = "0.3"
 default = ["limit-logs", "scroll"]
 scroll = ["scroll-zkvm-types/scroll", "sbv-utils/scroll"]
 cuda = ["scroll-zkvm-prover/cuda"]
+# halo2 (SNARK) proving on GPU; implies cuda. VRAM-heavy, see scroll-zkvm-prover.
+halo2-gpu = ["scroll-zkvm-prover/halo2-gpu"]
 limit-logs = []
 perf-metrics = ["openvm-sdk/perf-metrics"]

--- a/crates/integration/src/lib.rs
+++ b/crates/integration/src/lib.rs
@@ -301,7 +301,13 @@ impl TaskProver for Prover {
     }
 
     fn get_vk(&mut self) -> eyre::Result<Vec<u8>> {
-        Ok(self.get_app_vk())
+        // Use the program commitment published in openVmVk.json instead of
+        // deriving it from the prover: deriving constructs the (GPU) aggregation
+        // prover just to read the commitment.
+        let commitment = PROGRAM_COMMITMENTS
+            .get(self.prover_name.as_str())
+            .ok_or_else(|| eyre::eyre!("no program commitment for {}", self.prover_name))?;
+        Ok(serialize_vk::serialize(commitment))
     }
 
     fn get_agg_vk(
@@ -311,7 +317,7 @@ impl TaskProver for Prover {
             openvm_sdk::SC,
         >,
     > {
-        Ok((*self.sdk()?.agg_vk()).clone())
+        Ok((*self.load_agg_vk()?).clone())
     }
 
     fn deferral_cached_commit(&self) -> eyre::Result<openvm_continuations::CommitBytes> {
@@ -457,10 +463,9 @@ pub fn compute_deferral_data(
     cached_commit: openvm_continuations::CommitBytes,
     proofs: &[&StarkProof],
 ) -> eyre::Result<(Vec<[u8; 32]>, Vec<DeferralInput>, Vec<DeferralState>)> {
-    let sdk = child_prover
-        .sdk()
-        .map_err(|e| eyre::eyre!("failed to get child sdk: {e}"))?;
-    let mvk = (*sdk.agg_vk()).clone();
+    // Load the child agg VK from the pre-built asset when available; deriving it
+    // from the SDK constructs the child's (GPU) aggregation prover just for the VK.
+    let mvk = (*child_prover.load_agg_vk()?).clone();
 
     let (vm_proofs, baselines): (Vec<VmStarkProof>, Vec<VerificationBaseline>) = proofs
         .iter()

--- a/crates/integration/src/testers/bundle.rs
+++ b/crates/integration/src/testers/bundle.rs
@@ -71,6 +71,12 @@ impl BundleTaskGenerator {
         let wit = self.get_or_build_witness()?;
         let agg_proofs = self.get_or_build_child_proofs(batch_prover, chunk_prover)?;
         prover.enable_deferral(batch_prover)?;
+        // Release the child provers' SDKs before the bundle STARK/SNARK phase.
+        // Their GPU-resident proving keys are no longer needed (deferral data is
+        // already configured above, and child agg VKs are loaded from disk), and
+        // on 24 GB cards the halo2 GPU prover needs the headroom.
+        chunk_prover.reset();
+        batch_prover.reset();
         let proof = prove_verify_single_evm_with_deferral::<BundleProverTester>(
             prover,
             &wit,

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -41,5 +41,8 @@ cudarc = { version = "0.9", optional = true }
 [features]
 default = []
 cuda = ["openvm-sdk/cuda", "dep:cudarc", "openvm-verify-stark-circuit/cuda", "dep:openvm-cuda-backend"]
+# GPU acceleration for the halo2 (SNARK) prover on top of `cuda`. Needs much
+# more VRAM than STARK proving; enable only on 24 GB-class GPUs.
+halo2-gpu = ["cuda", "openvm-sdk/halo2-gpu"]
 
 

--- a/crates/prover/src/prover/mod.rs
+++ b/crates/prover/src/prover/mod.rs
@@ -143,6 +143,32 @@ impl Prover {
         self.get_sdk()
     }
 
+    /// File name of the serialized aggregation verifying key next to `app.vmexe`.
+    const FD_AGG_VK: &'static str = "agg_vk.bin";
+
+    /// Load this circuit's aggregation VK, preferring the pre-built asset
+    /// (`agg_vk.bin`, written by build-guest next to `app.vmexe`) so callers can
+    /// obtain the VK without constructing the aggregation prover. Constructing
+    /// the prover is expensive and, with the `cuda` feature, uploads several GiB
+    /// of proving keys to GPU memory that is never reclaimed.
+    ///
+    /// Falls back to deriving the VK from the SDK if the asset is missing.
+    pub fn load_agg_vk(
+        &self,
+    ) -> Result<Arc<openvm_stark_backend::keygen::types::MultiStarkVerifyingKey<SC>>, Error> {
+        let path = self.config.path_app_exe.with_file_name(Self::FD_AGG_VK);
+        match openvm_sdk::fs::read_object_from_file(&path) {
+            Ok(mvk) => Ok(Arc::new(mvk)),
+            Err(e) => {
+                tracing::warn!(
+                    "failed to read {} ({e}); deriving agg VK from SDK (slow, may allocate GPU memory)",
+                    path.display()
+                );
+                Ok(self.get_sdk()?.agg_vk())
+            }
+        }
+    }
+
     /// Pick up loaded app commit as "vk" in proof, to distinguish from which circuit the proof comes
     pub fn get_app_vk(&self) -> Vec<u8> {
         serialize_vk::serialize(&self.get_app_commitment())
@@ -177,7 +203,9 @@ impl Prover {
         // VK (root verifier VK). The cached commit must be the child's
         // internal-recursive VK commit, computed with commit_child_vk so it matches
         // what the child root proof exposes.
-        let child_agg_vk = child_sdk.agg_vk().clone();
+        // Load the child agg VK from the pre-built asset when available, so we
+        // don't construct the child's (GPU) aggregation prover just to get the VK.
+        let child_agg_vk = child_prover.load_agg_vk()?;
         let engine = <DeferralEngine as StarkEngine>::new(child_agg_vk.inner.params.clone());
         let internal_recursive_cached_commit: CommitBytes =
             commit_child_vk(&engine, &child_agg_vk, true)


### PR DESCRIPTION
Add a halo2-gpu cargo feature (prover -> openvm-sdk/halo2-gpu -> snark-verifier-sdk/cuda) that runs the halo2 SNARK aggregation prover on GPU in addition to STARK proving. The Makefile auto-enables it when GPU=1 and the GPU has >= 22 GiB VRAM (measured e2e peak ~23.5 GiB); override with HALO2_GPU=1/0.

The halo2 prover needs ~15 GiB of physically free VRAM at create_proof time, and openvm's VPMM pool never releases physical pages, so the live GPU set before the SNARK phase must stay small. To that end:

- build-guest now dumps each circuit's aggregation VK to agg_vk.bin, and Prover::load_agg_vk() reads it, so enable_deferral, compute_deferral_data and integration get_agg_vk() no longer build the child's GPU aggregation prover just to obtain the VK
- integration get_vk() uses PROGRAM_COMMITMENTS from openVmVk.json instead of Prover::get_app_vk(), which builds the GPU prover as a side effect
- the bundle tester resets child prover SDKs after enable_deferral

Also fix dependency resolution for snark-verifier-sdk/cuda: halo2-lib v0.5.4 was retagged upstream; update Cargo.lock to the new commit so halo2-axiom-gpu resolves to v1.0.0 and shares the stark-backend v2.0.0 source (avoids the links="cuda-common" conflict).

Verified on 2x RTX 4090: test-e2e-bundle (fresh and cached) and test-e2e-batch pass fully on GPU (SNARK proof ~5.7s, EVM verify gas 337615, peak VRAM ~23.5 GiB).